### PR TITLE
Persist theme and font size changes

### DIFF
--- a/embedded-chat.html
+++ b/embedded-chat.html
@@ -229,9 +229,9 @@
     sidInput.addEventListener('keydown',e=>{ if(e.key==='Enter'){ e.preventDefault(); saveSidBtn.click(); e.target.blur(); }});
     newSidBtn.addEventListener('click',()=>{ sidInput.value=uuidv4(); sidInput.select(); });
 
-    themeSelect.addEventListener('change',()=> document.documentElement.setAttribute('data-theme', themeSelect.value));
-    fontSelect.addEventListener('change',()=> document.documentElement.style.setProperty('--chat-text-size', fontSelect.value));
-    resetPrefs.addEventListener('click',()=>{ document.documentElement.setAttribute('data-theme','dark'); document.documentElement.style.setProperty('--chat-text-size','30px'); });
+    themeSelect.addEventListener('change',()=> setTheme(themeSelect.value));
+    fontSelect.addEventListener('change',()=> setFontSize(fontSelect.value));
+    resetPrefs.addEventListener('click',()=>{ setTheme('dark'); setFontSize('30px'); });
 
     sidPill.addEventListener('click',async()=>{ try{ await navigator.clipboard.writeText(getSessionId()); sidPill.title='Copied!'; setTimeout(()=>sidPill.title='Copy ID',1200) }catch{} });
     regen.addEventListener('click',()=>{ setSessionId(uuidv4()); logLine('Digital Intelligence','New session — fresh conversation context.'); });


### PR DESCRIPTION
## Summary
- Ensure theme selection calls `setTheme` to save preference
- Ensure font size selection calls `setFontSize`
- Reset preferences now stores default theme and font size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b31d875c188327bd1dd247447cd971